### PR TITLE
Integrate ca8210 driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "cpu/cc26xx/lib/cc26xxware"]
 	path = cpu/cc26xx/lib/cc26xxware
 	url = https://github.com/g-oikonomou/cc26xxware.git
+[submodule "dev/ca8210"]
+	path = dev/ca8210
+	url = git@github.com:FlowM2M/ca8210-contiki.git

--- a/platform/mikro-e/Makefile.mikro-e
+++ b/platform/mikro-e/Makefile.mikro-e
@@ -20,11 +20,24 @@ CONTIKI_PLAT_DEFS += -D __USE_UART_PORT3_FOR_DEBUG__
 
 CONTIKI_PLAT_DEFS += -D __USE_SPI__
 CONTIKI_PLAT_DEFS += -D __USE_SPI_PORT2__
+CONTIKI_PLAT_DEFS += -D __USE_SPI_PORT1__
 
 CONTIKI_TARGET_SOURCEFILES = contiki-mikro-e-main.c leds-arch.c platform-init.c \
-                             cc2520-arch.c net-init.c button-sensor.c serial-line.c
+                             net-init.c button-sensor.c serial-line.c
 
-MODULES += dev/cc2520 core/net core/net/mac core/net/llsec
+ifeq ($(USE_CC2520),1)
+  CONTIKI_PLAT_DEFS += -D __USE_CC2520__
+  CONTIKI_TARGET_SOURCEFILES +=  cc2520-arch.c
+  MODULES += dev/cc2520
+else
+ifeq ($(USE_CA8210),1)
+  CONTIKI_PLAT_DEFS += -D __USE_CA8210__
+  MODULES += dev/ca8210 dev/ca8210/ports/source dev/ca8210/cascoda/ariadne/source dev/ca8210/cascoda/source
+  MODULES += dev/ca8210/apps/test15_4/source
+endif
+endif
+
+MODULES += core/net core/net/mac core/net/llsec
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 

--- a/platform/mikro-e/Readme.md
+++ b/platform/mikro-e/Readme.md
@@ -16,8 +16,15 @@ Some key paths where IMG have added source code to support Contiki on Mikro-E Cl
 
 | Folder              				| Content                                              							                      |
 | :----               				| :----                                                							                      |
-| platform/mikro-e			      | Porting of drivers for peripherals like Button, LED, CC2520 etc. on Mikro-E Clicker			|
+| platform/mikro-e			      | Porting of drivers for peripherals like Button, LED, CC2520, CA8210 etc. on Mikro-E Clicker			|
 | examples/mikro-e            | Applications for Mikro-E Clicker board                                                  |         
+
+## Cascoda ca8210 transceiver support
+
+Cascoda ca8210 transceiver driver has been added git submodule. So you first need to checkout the driver code before building any contiki application based upon ca8210.
+
+    $ git submodule init "dev/ca8210"
+    $ git submodule update
 
 ## Getting Started
 
@@ -27,9 +34,16 @@ environment variables and compile an example, say "Hello World" which is include
 
     $ export PATH=$PATH:/opt/microchip/xc32/v1.34/bin/
 
-The application e.g. Hello World can be built for Mikro-E Clicker and HEX file can be generated to flash on the board as per below:
+Platform mikro-e makefile has been updated to build either for cc2520 or for ca8210 depending the build option USE_CC2520 or USE_CA8210. The application e.g. Hello World can be built for Mikro-E Clicker and HEX file can be generated to flash on the board as per below:
+
+For clicker boards using CA8210:
 
     $ cd examples/hello-world
-    $ make TARGET=mikro-e
+    $ make TARGET=mikro-e USE_CA8210=1
     $ /opt/microchip/xc32/v1.34/bin/xc32-bin2hex hello-world.mikro-e
 
+For clicker boards using CC2520:
+
+    $ cd examples/hello-world
+    $ make TARGET=mikro-e USE_CC2520=1
+    $ /opt/microchip/xc32/v1.34/bin/xc32-bin2hex hello-world.mikro-e

--- a/platform/mikro-e/ca8210-conf.h
+++ b/platform/mikro-e/ca8210-conf.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016, Cascoda Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*---------------------------------------------------------------------------*/
+// CA8210 Interrupt Mapping to PIC32 INT1
+/*---------------------------------------------------------------------------*/
+
+#ifndef CA8210_CONF_H
+#define CA8210_CONF_H
+
+#undef DEBUG /* Conflict with a macro named DEBUG defined in compiler */
+#include <p32xxxx.h>
+#undef DEBUG
+
+#include <pic32_gpio.h>
+#include <pic32_irq.h>
+
+
+/*---------------------------------------------------------------------------*/
+// Initialise Interrupt
+/*---------------------------------------------------------------------------*/
+#define CA8210_IRQN_INIT()                                               \
+  {                                                                      \
+  IFS0CLR = _IFS0_INT1IF_MASK;                                           \
+  INTCONCLR = _INTCON_INT1EP_MASK;                                       \
+  IPC1CLR = _IPC1_INT1IP_MASK | _IPC1_INT1IS_MASK;                       \
+  IPC1SET = (6 << _IPC1_INT1IP_POSITION) | (3 << _IPC1_INT1IS_POSITION); \
+  IEC0SET = _IEC0_INT1IE_MASK;                                           \
+  }
+
+
+/*---------------------------------------------------------------------------*/
+// Enable Interrupt
+/*---------------------------------------------------------------------------*/
+#define CA8210_IRQN_ENABLE()                                             \
+  {                                                                      \
+  IFS0CLR = _IFS0_INT1IF_MASK;                                           \
+  IEC0SET = _IEC0_INT1IE_MASK;                                           \
+  }
+
+
+/*---------------------------------------------------------------------------*/
+// Disable Interrupt
+/*---------------------------------------------------------------------------*/
+#define CA8210_IRQN_DISABLE()                                            \
+  {                                                                      \
+  IEC0CLR = _IEC0_INT1IE_MASK;                                           \
+  }
+
+
+/*---------------------------------------------------------------------------*/
+// Clear Interrupt
+/*---------------------------------------------------------------------------*/
+#define CA8210_IRQN_CLEAR()                                              \
+  {                                                                      \
+  IFS0CLR = _IFS0_INT1IF_MASK;                                           \
+  }
+
+
+#endif /* CA8210_CONF_H */

--- a/platform/mikro-e/contiki-mikro-e-main.c
+++ b/platform/mikro-e/contiki-mikro-e-main.c
@@ -38,7 +38,11 @@
 #include <platform-init.h>
 #include <debug-uart.h>
 #include <pic32_irq.h>
-#include <dev/cc2520/cc2520.h>
+#ifdef __USE_CC2520__
+  #include <dev/cc2520/cc2520.h>
+#elif  __USE_CA8210__
+  #include <dev/ca8210/ca8210-radio.h>
+#endif
 #include "dev/serial-line.h"
 #include <net-init.h>
 #include <leds.h>
@@ -102,8 +106,17 @@ ISR(_CHANGE_NOTICE_VECTOR)
   }
 }
 
-ISR(_EXTERNAL_1_VECTOR)
-{
+
+/*---------------------------------------------------------------------------*/
+#ifdef __USE_CC2520__
+ ISR(_EXTERNAL_1_VECTOR)
+ {
     cc2520_interrupt();
-}
+ }
+#elif __USE_CA8210__
+ ISR(_EXTERNAL_1_VECTOR)
+ {
+    ca8210_interrupt();
+ }
+#endif
 /*---------------------------------------------------------------------------*/

--- a/platform/mikro-e/net-init.c
+++ b/platform/mikro-e/net-init.c
@@ -35,9 +35,11 @@
 
 #include <lib/random.h>
 #include <time.h>
-
-#include <dev/cc2520/cc2520.h>
-
+#ifdef __USE_CC2520__
+  #include <dev/cc2520/cc2520.h>
+#elif  __USE_CA8210__
+  #include <dev/ca8210/ca8210-radio.h>
+#endif
 #define DEBUG 1
 #if DEBUG
 #include <stdio.h>
@@ -58,12 +60,20 @@ net_init()
   uint8_t i;
 
   queuebuf_init();
-  cc2520_init();
+  #ifdef __USE_CC2520__
+    cc2520_init();
+  #elif  __USE_CA8210__
+    ca8210_init();
+  #endif
 
   memset(&shortaddr, 0, sizeof(shortaddr));
   memset(&longaddr, 0, sizeof(longaddr));
   #ifndef FIXED_MAC_ADDRESS
-  cc2520_get_random((uint8_t *)&longaddr, sizeof(longaddr));
+  #ifdef __USE_CC2520__
+    cc2520_get_random((uint8_t *)&longaddr, sizeof(longaddr));
+  #elif  __USE_CA8210__
+    ca8210_get_random((uint8_t *)&longaddr, sizeof(longaddr));
+  #endif
   #else
   longaddr = FIXED_MAC_ADDRESS;
   #endif
@@ -76,8 +86,13 @@ net_init()
   }
   linkaddr_set_node_addr(&addr);
 
-  cc2520_set_channel(RF_CHANNEL);
-  cc2520_set_pan_addr(IEEE802154_PANID, shortaddr, (uint8_t *)&longaddr);
+  #ifdef __USE_CC2520__
+    cc2520_set_channel(RF_CHANNEL);
+    cc2520_set_pan_addr(IEEE802154_PANID, shortaddr, (uint8_t *)&longaddr);
+  #elif  __USE_CA8210__
+    ca8210_init_pib(RF_CHANNEL, IEEE802154_PANID, shortaddr, (uint8_t *)&longaddr);
+  #endif
+
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
   NETSTACK_NETWORK.init();

--- a/platform/mikro-e/platform-init.c
+++ b/platform/mikro-e/platform-init.c
@@ -84,9 +84,19 @@ platform_init()
   TRISGCLR = _TRISG_TRISG8_MASK;
   RPG8R = 0b0110;
 
-  /* INT1 for FIFOP: RD5 */
-  TRISDSET = _TRISD_TRISD5_MASK;
-  INT1R = 0b0110;
+  #ifdef __USE_CC2520__
+
+    /* INT1 for CC2520 FIFOP: RD5 */
+    TRISDSET = _TRISD_TRISD5_MASK;
+    INT1R = 0b0110;
+
+  #elif __USE_CA8210
+
+    /* INT1 for CA8210 NIRQ: RD1 */
+    TRISDSET = _TRISD_TRISD1_MASK;
+    INT1R = 0b0000;
+
+  #endif
 
   /* Lock again */
   CFGCONbits.IOLOCK=1;


### PR DESCRIPTION
Add ca8210 as git submodule.
There are two flags in platform/mikro-e/Makefile.mikro-e
**USE_CC2520** or **USE_CA8210**
Depending upon the mikro-e clicker board, choose one of them.

Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
Signed-off-by: Pratik Prajapati Pratik.Prajapati@imgtec.com
