### PR TITLE
I2C driver refactoring & NACK bit set

### DIFF
--- a/cpu/pic32/lib/pic32_i2c.c
+++ b/cpu/pic32/lib/pic32_i2c.c
@@ -101,7 +101,7 @@
     return 0;                                                            \
   }                                                                      \
   uint8_t                                                                \
-  i2c##XX##_send_bytes(uint8_t *ptr, uint8_t length)                     \
+  i2c##XX##_send_bytes(const uint8_t *ptr, uint8_t length)               \
   {                                                                      \
     while(length) {                                                      \
     if(i2c##XX##_send_byte(*ptr))                                        \

--- a/cpu/pic32/lib/pic32_i2c.h
+++ b/cpu/pic32/lib/pic32_i2c.h
@@ -52,7 +52,9 @@
   uint8_t i2c##XX##_send_stop();                             \
   uint8_t i2c##XX##_send_byte(uint8_t );                     \
   uint8_t i2c##XX##_send_bytes (uint8_t *, uint8_t );        \
-  uint8_t i2c##XX##_set_nack(uint8_t bit);				     \
+  /* Set this before the final receive to send NACK. */      \
+  /* The driver will reset the nack after the read */        \
+  uint8_t i2c##XX##_set_nack(uint8_t bit);                   \
   uint8_t i2c##XX##_receive_byte(uint8_t *);                 \
   uint8_t i2c##XX##_receive_bytes(uint8_t *, uint8_t );
 /*---------------------------------------------------------------------------*/

--- a/cpu/pic32/lib/pic32_i2c.h
+++ b/cpu/pic32/lib/pic32_i2c.h
@@ -51,7 +51,7 @@
   uint8_t i2c##XX##_send_repeated_start();                   \
   uint8_t i2c##XX##_send_stop();                             \
   uint8_t i2c##XX##_send_byte(uint8_t );                     \
-  uint8_t i2c##XX##_send_bytes (uint8_t *, uint8_t );        \
+  uint8_t i2c##XX##_send_bytes(const uint8_t *, uint8_t );   \
   /* Set this before the final receive to send NACK. */      \
   /* The driver will reset the nack after the read */        \
   uint8_t i2c##XX##_set_nack(uint8_t bit);                   \

--- a/cpu/pic32/lib/pic32_i2c.h
+++ b/cpu/pic32/lib/pic32_i2c.h
@@ -32,7 +32,7 @@
  */
 
 /**
- * \file   
+ * \file
  * 	I2C driver for PIC32MX (pic32mx470f512h)
  */
 
@@ -50,12 +50,13 @@
   uint8_t i2c##XX##_send_start();                            \
   uint8_t i2c##XX##_send_repeated_start();                   \
   uint8_t i2c##XX##_send_stop();                             \
-  uint8_t i2c##XX##_byte_send(uint8_t );                     \
-  uint8_t i2c##XX##_byte_receive(uint8_t *);                 \
-  uint8_t i2c##XX##_burst_send (uint8_t *, uint8_t );        \
-  uint8_t i2c##XX##_burst_receive(uint8_t *, uint8_t );      
+  uint8_t i2c##XX##_send_byte(uint8_t );                     \
+  uint8_t i2c##XX##_send_bytes (uint8_t *, uint8_t );        \
+  uint8_t i2c##XX##_set_nack(uint8_t bit);				     \
+  uint8_t i2c##XX##_receive_byte(uint8_t *);                 \
+  uint8_t i2c##XX##_receive_bytes(uint8_t *, uint8_t );
 /*---------------------------------------------------------------------------*/
-               
+
 #ifdef __32MX470F512H__
   #ifdef __USE_I2C_PORT1__
   I2C_DEF(1)

--- a/platform/mikro-e/apps/test-i2c/test-i2c.c
+++ b/platform/mikro-e/apps/test-i2c/test-i2c.c
@@ -67,7 +67,7 @@ PROCESS_THREAD(test_i2c, ev, data)
   i2c1_master_enable();
   i2c1_send_start();
   /*pass the array to be send and no.of byte*/
-  if(i2c1_burst_send (send_data, 4)) {	
+  if(i2c1_send_bytes (send_data, 4)) {
     printf("Failed the connection to slave\n");
   }
   i2c1_send_stop();
@@ -75,9 +75,9 @@ PROCESS_THREAD(test_i2c, ev, data)
     etimer_set(&et, CLOCK_SECOND);
     i2c1_send_start();
     /*commond to TMP102 write data on bus*/
-    i2c1_byte_send(TMP102_READ_ADDRESS);
+    i2c1_send_byte(TMP102_READ_ADDRESS);
     /*pass the array to be receive and no.of byte*/
-    if(i2c1_burst_receive(receive_data, 2)) {
+    if(i2c1_receive_bytes(receive_data, 2)) {
       printf("Failed to receiving the data form slave\n");
     }
     i2c1_send_stop();

--- a/platform/mikro-e/dev/proximity-click/proximity-click.c
+++ b/platform/mikro-e/dev/proximity-click/proximity-click.c
@@ -78,34 +78,34 @@ proximity_sensor_configure(int type, int value)
           i2c1_master_enable();
           i2c1_send_start();
           /* proximity data enable and selftime enable */
-          i2c1_byte_send(WRITE_ADDR);
-          i2c1_byte_send(COMMAND_REG);
-          i2c1_byte_send(PROXIMITY_SELFTIME_EN);
+          i2c1_send_byte(WRITE_ADDR);
+          i2c1_send_byte(COMMAND_REG);
+          i2c1_send_byte(PROXIMITY_SELFTIME_EN);
           i2c1_send_repeated_start();
           /* proximity measurement rate 4  measurement pre second */
-          i2c1_byte_send(WRITE_ADDR);
-          i2c1_byte_send(PROXIMITY_RATE_REG);
-          i2c1_byte_send(PROXIMITY_RATE_4);
+          i2c1_send_byte(WRITE_ADDR);
+          i2c1_send_byte(PROXIMITY_RATE_REG);
+          i2c1_send_byte(PROXIMITY_RATE_4);
           i2c1_send_repeated_start();
           /* IRLED current 100 mA */
-          i2c1_byte_send(WRITE_ADDR);
-          i2c1_byte_send(IRLED_CUURENT_REG);
-          i2c1_byte_send(IRLED_CURRENT_100MA);
+          i2c1_send_byte(WRITE_ADDR);
+          i2c1_send_byte(IRLED_CUURENT_REG);
+          i2c1_send_byte(IRLED_CURRENT_100MA);
           i2c1_send_repeated_start();
           /* High threshold register upper byte */
-          i2c1_byte_send(WRITE_ADDR);
-          i2c1_byte_send(HIGH_THRESHOLD_UPPER_REG);
-          i2c1_byte_send(THRESHOLD_UPPER_BYTE);
+          i2c1_send_byte(WRITE_ADDR);
+          i2c1_send_byte(HIGH_THRESHOLD_UPPER_REG);
+          i2c1_send_byte(THRESHOLD_UPPER_BYTE);
           i2c1_send_repeated_start();
           /* High threshold register lower byte */
-          i2c1_byte_send(WRITE_ADDR);
-          i2c1_byte_send(HIGH_THRESHOLD_LOWER_REG);
-          i2c1_byte_send(THRESHOLD_LOWER_BYTE);
+          i2c1_send_byte(WRITE_ADDR);
+          i2c1_send_byte(HIGH_THRESHOLD_LOWER_REG);
+          i2c1_send_byte(THRESHOLD_LOWER_BYTE);
           i2c1_send_repeated_start();
           /* Enable interrupt for Proximity sensor */
-          i2c1_byte_send(WRITE_ADDR);
-          i2c1_byte_send(INTERRUPT_CONTROL_REG);
-          i2c1_byte_send(INTERRUPT_REG_SETTING);
+          i2c1_send_byte(WRITE_ADDR);
+          i2c1_send_byte(INTERRUPT_CONTROL_REG);
+          i2c1_send_byte(INTERRUPT_REG_SETTING);
           i2c1_send_stop();
           i2c1_master_disable();
           PROXIMITY_SENSOR_IRQ_ENABLE();
@@ -132,17 +132,17 @@ proximity_sensor_value(int type)
   int     value;
   i2c1_master_enable();
   i2c1_send_start();
-  i2c1_byte_send(WRITE_ADDR);
-  i2c1_byte_send(PROXIMITY_DATA_UPPER_REG);
+  i2c1_send_byte(WRITE_ADDR);
+  i2c1_send_byte(PROXIMITY_DATA_UPPER_REG);
   i2c1_send_repeated_start();
-  i2c1_byte_send(READ_ADDR);
-  i2c1_byte_receive(data);
+  i2c1_send_byte(READ_ADDR);
+  i2c1_receive_byte(data);
   i2c1_send_repeated_start();
-  i2c1_byte_send(WRITE_ADDR);
-  i2c1_byte_send(PROXIMITY_DATA_LOWER_REG);
+  i2c1_send_byte(WRITE_ADDR);
+  i2c1_send_byte(PROXIMITY_DATA_LOWER_REG);
   i2c1_send_repeated_start();
-  i2c1_byte_send(READ_ADDR);
-  i2c1_byte_receive(data + 1);
+  i2c1_send_byte(READ_ADDR);
+  i2c1_receive_byte(data + 1);
   i2c1_send_stop();
   i2c1_master_disable();
   value = ((uint16_t)data[0] << 8) | data[1];

--- a/platform/mikro-e/dev/proximity-click/proximity-click.h
+++ b/platform/mikro-e/dev/proximity-click/proximity-click.h
@@ -95,9 +95,9 @@ is exceeded.
     do{                                                                   \
         i2c1_master_enable();                                             \
         i2c1_send_start();                                                \
-        i2c1_byte_send(WRITE_ADDR);                                       \
-        i2c1_byte_send(INTERRUPT_STATUS_REG);                             \
-        i2c1_byte_send(INTERRUPT_RESET);                                  \
+        i2c1_send_byte(WRITE_ADDR);                                       \
+        i2c1_send_byte(INTERRUPT_STATUS_REG);                             \
+        i2c1_send_byte(INTERRUPT_RESET);                                  \
         i2c1_send_stop();                                                 \
         i2c1_master_disable();                                            \
         (void)PORTD;                                                      \

--- a/platform/mikro-e/dev/thermo3-click/thermo3-click.c
+++ b/platform/mikro-e/dev/thermo3-click/thermo3-click.c
@@ -53,24 +53,24 @@ void tmp102_reg_select(uint8_t reg)
 {
   i2c1_master_enable();
   i2c1_send_start();
-    if(i2c1_byte_send (TMP102_REG_WRITE)) {
+    if(i2c1_send_byte (TMP102_REG_WRITE)) {
       i2c1_send_repeated_start();
-      if(i2c1_byte_send (TMP102_REG_WRITE)) {
+      if(i2c1_send_byte (TMP102_REG_WRITE)) {
         printf("Failed the connection to Thermo3\n");
       }		
     }
   switch (reg) {
     case TMP102_TEMP:
-      i2c1_byte_send (TMP102_TEMP);
+      i2c1_send_byte (TMP102_TEMP);
       break;
     case TMP102_CONF:
-      i2c1_byte_send (TMP102_CONF);
+      i2c1_send_byte (TMP102_CONF);
       break;
     case TMP102_TLOW:
-      i2c1_byte_send (TMP102_TLOW);
+      i2c1_send_byte (TMP102_TLOW);
       break;
     case TMP102_THIGH:
-      i2c1_byte_send (TMP102_THIGH);
+      i2c1_send_byte (TMP102_THIGH);
       break;
     default:
       printf("Invalid Register Address\n");
@@ -85,11 +85,11 @@ void tmp102_reg_read(uint8_t *data)
   i2c1_master_enable();
   i2c1_send_start();
   /*command to TMP102 to Write data on bus */
-  if(i2c1_byte_send (TMP102_REG_READ)) {
+  if(i2c1_send_byte (TMP102_REG_READ)) {
     printf("Failed the connection to Thermo3\n");	
   }
-  i2c1_byte_receive(data);
-  i2c1_byte_receive((data + 1));
+  i2c1_receive_byte(data);
+  i2c1_receive_byte((data + 1));
   i2c1_send_stop();
   i2c1_master_disable();
 }
@@ -99,9 +99,9 @@ void tmp102_reg_write(uint8_t msb, uint8_t lsb)
   i2c1_master_enable();
   i2c1_send_start();
   /*command to TMP102 to Read data from bus */
-  i2c1_byte_send (TMP102_REG_WRITE);
-  i2c1_byte_send(msb);
-  i2c1_byte_send(lsb);
+  i2c1_send_byte (TMP102_REG_WRITE);
+  i2c1_send_byte(msb);
+  i2c1_send_byte(lsb);
   i2c1_send_stop();
   i2c1_master_disable();
 }


### PR DESCRIPTION
Cleaned up function names to be more consistent (send_start & send_byte instead of send_start and byte_send, renamed burst_receive to just receive_bytes), added NACK to support all clicks.
