### PR TITLE
platform/mikro-e: Use serial pads defaults to Mikrobus

### DIFF
--- a/platform/mikro-e/Makefile.mikro-e
+++ b/platform/mikro-e/Makefile.mikro-e
@@ -10,14 +10,14 @@ CONTIKI_PLAT_DEFS += -D __USE_TIMER_23__ -D PIC32_TIMER_RTIMER=23
 
 CONTIKI_PLAT_DEFS += -D __USE_UART__
 
-ifeq ($(USE_SERIAL_PADS),0)
-  #If using RF4 and RF5 as uart pins for debug
-  CONTIKI_PLAT_DEFS += -D __USE_UART_PORT3__
-  CONTIKI_PLAT_DEFS += -D __USE_UART_PORT3_FOR_DEBUG__
-else
+ifeq ($(USE_SERIAL_PADS),1)
   #If using RB9 and RD11 as uart pins for debug
   CONTIKI_PLAT_DEFS += -D __USE_UART_PORT2__
   CONTIKI_PLAT_DEFS += -D __USE_UART_PORT2_FOR_DEBUG__
+else
+  #If using RF4 and RF5 as uart pins for debug
+  CONTIKI_PLAT_DEFS += -D __USE_UART_PORT3__
+  CONTIKI_PLAT_DEFS += -D __USE_UART_PORT3_FOR_DEBUG__
 endif
 
 CONTIKI_PLAT_DEFS += -D __USE_SPI__


### PR DESCRIPTION
The initial commit by default would use serial pads, which is in the end not the preferred behaviour. This doesn't change much apart from making sure that if USE_SERIAL_PADS is not defined it will use the Mikrobus line.
