### PR TITLE
Disable watchdog when using Avrdude

### DIFF
--- a/cpu/pic32/Makefile.pic32
+++ b/cpu/pic32/Makefile.pic32
@@ -43,6 +43,7 @@ CFLAGS += -mprocessor=$(PIC32_MODEL)
 LDFLAGS += -mprocessor=$(PIC32_MODEL) -Wl,-Map=contiki-$(TARGET).map -s
 ifeq ($(USE_AVRDUDE),1)
 LDFLAGS += -Wl,--script="$(CONTIKI_CPU)/app_$(PIC32_MODEL).ld"
+CFLAGS += -D__USE_AVRDUDE__
 endif
 LDFLAGS += -Wl,--defsym,_min_stack_size=4096 -Wl,--gc-sections
 endif

--- a/platform/mikro-e/contiki-mikro-e-main.c
+++ b/platform/mikro-e/contiki-mikro-e-main.c
@@ -94,16 +94,22 @@ main(int argc, char **argv)
   serial_line_init();
 
   autostart_start(autostart_processes);
+#ifndef __USE_AVRDUDE__
   watchdog_start();
+#endif
 
   while(1) {
     do {
+#ifndef __USE_AVRDUDE__
       watchdog_periodic();
+#endif
       r = process_run();
     } while(r > 0);
+#ifndef __USE_AVRDUDE__
     watchdog_stop();
     asm volatile("wait");
     watchdog_start();
+#endif
   }
 
   return 0;


### PR DESCRIPTION
This fixes the process restart on PROCESS_YIELD, see mtusnio/LetMeCreateIoT#3 
